### PR TITLE
Fix add to cart for unavailable items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add to cart with unavailable items.
+
 ## [0.5.0] - 2020-09-28
 
 ### Added

--- a/react/components/BuyTogether/index.tsx
+++ b/react/components/BuyTogether/index.tsx
@@ -19,7 +19,7 @@ const { ProductGroupProvider, useProductGroup } = ProductGroupContext
 interface Props {
   title?: string
   suggestedProducts?: Product[][]
-  BuyButton: React.ComponentType<{ skuItems: any[] }>
+  BuyButton: React.ComponentType<{ skuItems: CartItem[] }>
 }
 
 const { ProductListProvider } = ProductListContext
@@ -41,6 +41,8 @@ const CSS_HANDLES = [
   'buyTogetherTitle',
   'totalValue',
 ]
+
+const notNull = (item: CartItem | null): item is CartItem => item !== null
 
 const BuyTogether: StorefrontFunctionComponent<Props> = ({
   title,
@@ -106,18 +108,15 @@ const BuyTogether: StorefrontFunctionComponent<Props> = ({
   }
 
   const cartItems = useMemo(() => {
-    return mapSKUItemsToCartItems(filteredItems)
+    return mapSKUItemsToCartItems(filteredItems).filter(notNull)
   }, [filteredItems])
 
   const totalProducts = cartItems.length
   const totalPrice = useMemo(() => {
-    return filteredItems.reduce((total: number, currentItem: Item) => {
-      if (currentItem.selectedItem.seller?.commertialOffer.Price) {
-        return total + currentItem.selectedItem.seller.commertialOffer?.Price
-      }
-      return total + currentItem.selectedItem.sellers[0]?.commertialOffer?.Price
+    return cartItems.reduce((total: number, currentItem: CartItem) => {
+      return total + currentItem.price / 100
     }, 0)
-  }, [filteredItems])
+  }, [cartItems])
 
   return (
     <div className={`flex-none tc ${handles.buyTogetherContainer}`}>

--- a/react/components/RefreshShelf/RefreshProductSummary.tsx
+++ b/react/components/RefreshShelf/RefreshProductSummary.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import ProductSummary from 'vtex.product-summary/ProductSummaryCustom'
-import { ButtonWithIcon } from 'vtex.styleguide'
+import { ButtonPlain } from 'vtex.styleguide'
 import { useIntl, defineMessages } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
 
@@ -59,15 +59,13 @@ const RefreshProductSummary: StorefrontFunctionComponent<RefreshProductSummaryPr
       <div
         className={`nowrap mv4 f4 v-mid ${handles.refreshProductTitleContainer}`}
       >
-        <span className={styles.refreshProductTitle}>
+        <span className={`mr3 ${styles.refreshProductTitle}`}>
           {title && title !== '' ? title : intl.formatMessage(messages.title)}
         </span>
         {products?.length > 1 && (
-          <ButtonWithIcon
-            icon={<IconRefresh size={20} />}
-            variation="tertiary"
-            onClick={handleRefresh}
-          />
+          <ButtonPlain onClick={handleRefresh} className="ml2">
+            <IconRefresh size={20} />
+          </ButtonPlain>
         )}
       </div>
       {loading && <ProductSummaryLoader />}

--- a/react/components/RefreshShelf/styles.css
+++ b/react/components/RefreshShelf/styles.css
@@ -26,11 +26,11 @@
 }
 
 .suggestedProductsTitle {
-  vertical-align: -webkit-baseline-middle;
+  vertical-align: middle;
 }
 
 .refreshProductTitle {
-  vertical-align: -webkit-baseline-middle;
+  vertical-align: middle;
 }
 
 @media screen and (min-width: 64.125em) {

--- a/react/package.json
+++ b/react/package.json
@@ -24,7 +24,7 @@
     "graphql": "^14.7.0",
     "prop-types": "^15.7.2",
     "react-content-loader": "^5.1.0",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "vtex.add-to-cart-button": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.add-to-cart-button@0.13.5/public/@types/vtex.add-to-cart-button",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles",
     "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.4/public/@types/vtex.device-detector",

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -52,6 +52,38 @@ declare global {
     selectedItem: SKU
   }
 
+  interface CartItem {
+    id: string
+    productId: string
+    quantity: number
+    uniqueId: string
+    detailUrl: string
+    name: string
+    brand: string
+    category: string
+    productRefId: string
+    seller: string
+    variant: string
+    skuName: string
+    price: number
+    listPrice: number
+    sellingPrice: number
+    sellingPriceWithAssemblies: number
+    measurementUnit: string
+    skuSpecifications: any[]
+    imageUrl: string
+    options: any[]
+    assemblyOptions: {
+      added: any[]
+      removed: any[]
+      parentPrice: number
+    }
+    referenceId: Array<{
+      Key: string
+      Value: string
+    }> | null
+  }
+
   interface SKU {
     ean?: string
     images: Array<{

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -1,5 +1,6 @@
 declare module 'vtex.styleguide' {
   export const ButtonWithIcon
+  export const ButtonPlain
   export const IconClear
   export const IconPlusLines
 }

--- a/react/utils.ts
+++ b/react/utils.ts
@@ -1,4 +1,6 @@
-export const mapSKUItemsToCartItems = (skuItems: Item[]) =>
+export const mapSKUItemsToCartItems = (
+  skuItems: Item[]
+): Array<CartItem | null> =>
   skuItems.map(item => {
     const {
       selectedItem: {
@@ -21,6 +23,10 @@ export const mapSKUItemsToCartItems = (skuItems: Item[]) =>
     } = item
     const selectedSeller = seller ?? sellers[0]
 
+    if (!selectedSeller) {
+      return null
+    }
+
     return {
       id: itemId,
       productId,
@@ -31,13 +37,13 @@ export const mapSKUItemsToCartItems = (skuItems: Item[]) =>
       brand,
       category: categories && categories.length > 0 ? categories[0] : '',
       productRefId: productReference,
-      seller: selectedSeller?.sellerId,
+      seller: selectedSeller.sellerId,
       variant: name,
       skuName: name,
-      price: selectedSeller?.commertialOffer.PriceWithoutDiscount * 100,
-      listPrice: selectedSeller?.commertialOffer.ListPrice * 100,
-      sellingPrice: selectedSeller?.commertialOffer.Price * 100,
-      sellingPriceWithAssemblies: selectedSeller?.commertialOffer.Price * 100,
+      price: selectedSeller.commertialOffer.PriceWithoutDiscount * 100,
+      listPrice: selectedSeller.commertialOffer.ListPrice * 100,
+      sellingPrice: selectedSeller.commertialOffer.Price * 100,
+      sellingPriceWithAssemblies: selectedSeller.commertialOffer.Price * 100,
       measurementUnit,
       skuSpecifications: [],
       imageUrl: images[0]?.imageUrl,
@@ -45,7 +51,7 @@ export const mapSKUItemsToCartItems = (skuItems: Item[]) =>
       assemblyOptions: {
         added: [],
         removed: [],
-        parentPrice: selectedSeller?.commertialOffer.Price,
+        parentPrice: selectedSeller.commertialOffer.Price,
       },
       referenceId,
     }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4689,10 +4689,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.7.3:
   version "3.9.5"


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Ignore item in Buy Together add to cart button if the selected sku is unavailable

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
currently add to cart adds products even if they are unavailable, which causes unwanted behavior in some places:

![image](https://user-images.githubusercontent.com/20840671/95910161-02404300-0d76-11eb-8bbc-faa1395488a9.png)

![image (1)](https://user-images.githubusercontent.com/20840671/95910173-05d3ca00-0d76-11eb-8c9f-d92683d87b79.png)


#### How should this be manually tested?

[Workspace](https://rec--storecomponents.myvtex.com/classic-shoes/p)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/20840671/95910309-43385780-0d76-11eb-9ed6-b165f9a3305d.png)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
