### PR TITLE
Fix buy together shelf on desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Buy together shelf on desktop.
+- Total price using `sellingPrice`.
 
 ## [0.7.0] - 2020-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Buy together shelf on desktop.
+
 ## [0.7.0] - 2020-12-16
 
 ### Changed

--- a/react/components/BuyTogether/index.tsx
+++ b/react/components/BuyTogether/index.tsx
@@ -131,7 +131,7 @@ const BuyTogether: StorefrontFunctionComponent<Props> = ({
   const totalProducts = cartItems.length
   const totalPrice = useMemo(() => {
     return cartItems.reduce((total: number, currentItem: CartItem) => {
-      return total + currentItem.price / 100
+      return total + currentItem.sellingPrice / 100
     }, 0)
   }, [cartItems])
 

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -95,6 +95,9 @@
       "product-summary-sku-selector#buy-together"
     ]
   },
+  "flex-layout.row#product-summary-desktop": {
+    "children": ["flex-layout.col#product-summary-desktop"]
+  },
 
   "responsive-layout.phone#product-summary": {
     "children": ["flex-layout.row#product-summary-mobile"]
@@ -104,7 +107,7 @@
   },
 
   "responsive-layout.desktop#product-summary": {
-    "children": ["flex-layout.col#product-summary-desktop"]
+    "children": ["flex-layout.row#product-summary-desktop"]
   },
 
   "product-summary.shelf#buy-together": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The `product-summary` block was not being displayed due to the flex-layout. Also, the total price should use `sellingPrice` instead of `price`

#### How should this be manually tested?

[Workspace](https://recommendation--calvinklein.myvtex.com/jaqueta-jeans-masculina-trucker-preta-calvin-klein-cm0oc07oj506_0987/p)

#### Screenshots or example usage

Before:
![image](https://user-images.githubusercontent.com/20840671/107236650-ab393a80-6a04-11eb-8f16-1b83bed62fad.png)

After:
![image](https://user-images.githubusercontent.com/20840671/107236243-454cb300-6a04-11eb-985b-a7e2848f0b82.png)

Using `sellingPrice`:
![image](https://user-images.githubusercontent.com/20840671/107256142-e133ea00-6a17-11eb-877c-318a5938b8a8.png)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
